### PR TITLE
Fix secret being deleted when it does not have target

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: service
-version: 2.2.0
+version: 2.2.1
 description: Helm chart for Circuit service definition

--- a/charts/service/templates/06_secret.yaml
+++ b/charts/service/templates/06_secret.yaml
@@ -19,6 +19,7 @@ spec:
   secretStoreRef:
     kind: ClusterSecretStore
     name: cluster-gcpsm-secret-store
+  target: {}
   data:
   - secretKey: {{ $environment.secret.name }}
     remoteRef:


### PR DESCRIPTION
This fix follows a workaround as shown on the following issue:
https://github.com/external-secrets/external-secrets/issues/1233