### PR TITLE
Add max unavailable pods

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: service
-version: 3.2.0
+version: 3.3.0
 description: Helm chart for Circuit service definition

--- a/charts/service/templates/01_rollout.yaml
+++ b/charts/service/templates/01_rollout.yaml
@@ -58,6 +58,7 @@ metadata:
 spec:
   strategy:
     canary:
+      maxUnavailable: "30%"
       canaryService: {{ printf "%s-canary" $name }}
       stableService: {{ printf "%s-stable" $name }}
       trafficRouting:

--- a/charts/service/templates/01_rollout.yaml
+++ b/charts/service/templates/01_rollout.yaml
@@ -58,7 +58,8 @@ metadata:
 spec:
   strategy:
     canary:
-      maxUnavailable: "30%"
+      maxUnavailable: "0%"
+      maxSurge: "50%"
       canaryService: {{ printf "%s-canary" $name }}
       stableService: {{ printf "%s-stable" $name }}
       trafficRouting:

--- a/charts/service/templates/01_rollout.yaml
+++ b/charts/service/templates/01_rollout.yaml
@@ -58,7 +58,7 @@ metadata:
 spec:
   strategy:
     canary:
-      maxUnavailable: "0%"
+      maxUnavailable: "30%"
       maxSurge: "50%"
       canaryService: {{ printf "%s-canary" $name }}
       stableService: {{ printf "%s-stable" $name }}


### PR DESCRIPTION
According to:
- https://argoproj.github.io/argo-rollouts/features/canary/#maxunavailable, rounded down
- https://argoproj.github.io/argo-rollouts/features/canary/#maxsurge, rounded up

This increase the number of pods rolling out at a time based on how many pods are currently running. As the maxUnavailable is always rounded down it does mean that if there are less than 3 pods none are deleted until new ones are rolled out.