### PR TITLE
Enable JWT validation using istio

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: service
-version: 3.4.0
+version: 3.5.0
 description: Helm chart for Circuit service definition

--- a/charts/service/templates/07_auth.yaml
+++ b/charts/service/templates/07_auth.yaml
@@ -1,0 +1,54 @@
+{{- range $k, $environment := .Values.environments }}
+
+{{- if $environment.auth }}
+
+{{- if not $environment.auth.issuer }}
+{{ fail "You must provide the issuer when enabling auth" }}
+{{- end }}
+
+{{- if not $environment.auth.jwksUri }}
+{{ fail "You must provide the jwksUri when enabling auth" }}
+{{- end }}
+
+{{ $name := printf "%s--%s" $environment.name $.Values.name }}
+{{- if and $environment.production (not $environment.name) }}
+  {{ $name = $.Values.name }}
+{{- end }}
+
+{{ $namespace := $.Values.global.stagingNamespace }}
+{{- if $environment.production }}
+  {{ $namespace = $.Values.global.prodNamespace }}
+{{- end }}
+
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
+metadata:
+  name: {{ $name }}
+  namespace: {{ $namespace }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ $name }}
+  jwtRules:
+  - issuer: {{ $environment.auth.issuer }}
+    jwksUri: {{ $environment.auth.jwksUri }}
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ $name }}
+  namespace: {{ $namespace }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ $name }}
+  action: ALLOW
+  rules:
+  - when:
+    - key: request.auth.claims[iss]
+      values:
+      - {{ $environment.auth.issuer }}
+---
+{{- end }}
+
+{{- end }}

--- a/charts/service/values-test-multi.yaml
+++ b/charts/service/values-test-multi.yaml
@@ -27,6 +27,9 @@ environments:
       prefix: "/health"
   version: v0.0.2
   targetCPU: 80
+  auth:
+    issuer: testing@secure.istio.io
+    jwksUri: https://raw.githubusercontent.com/istio/istio/release-1.16/security/tools/jwt/samples/jwks.json
   public: true
   volumes:
     secrets:
@@ -90,6 +93,9 @@ environments:
   maxReplicas: 5
   port: 3000
   production: false
+  auth:
+    issuer: testing@secure.istio.io
+    jwksUri: https://raw.githubusercontent.com/istio/istio/release-1.16/security/tools/jwt/samples/jwks.json
   name: staging
   imagePullPolicy: Always
   command: ["my", "custom", "command"]


### PR DESCRIPTION
The `auth` option can be used to validate the `Authorization` HTTP header for all requests to the app.

It's possible to add a filter in the future to request authentication only for specific endpoints.