### PR TITLE
Forward original token when using authentication

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: service
-version: 3.5.0
+version: 3.5.1
 description: Helm chart for Circuit service definition

--- a/charts/service/templates/07_auth.yaml
+++ b/charts/service/templates/07_auth.yaml
@@ -32,6 +32,7 @@ spec:
   jwtRules:
   - issuer: {{ $environment.auth.issuer }}
     jwksUri: {{ $environment.auth.jwksUri }}
+    forwardOriginalToken: true
 ---
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy


### PR DESCRIPTION
Without this option set, `istio` removes the `Authentication` header for the upstream request.