### PR TITLE
Ignore auth on pre-flight requests

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: service
-version: 3.6.0
+version: 3.6.1
 description: Helm chart for Circuit service definition

--- a/charts/service/templates/07_auth.yaml
+++ b/charts/service/templates/07_auth.yaml
@@ -45,6 +45,9 @@ spec:
       app.kubernetes.io/name: {{ $name }}
   action: ALLOW
   rules:
+  - to:
+    - operation:
+        methods: ['OPTIONS']
   - when:
     - key: request.auth.claims[iss]
       values:


### PR DESCRIPTION
Istio is preventing requests from being made from browsers as the pre-flight requests fail due to not having auth headers as mandated by the [CORS spec](https://fetch.spec.whatwg.org/#cors-protocol-and-credentials)
