### PR TITLE
Add auth.allowPaths to auth

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: service
-version: 3.6.1
+version: 3.7.0
 description: Helm chart for Circuit service definition

--- a/charts/service/templates/07_auth.yaml
+++ b/charts/service/templates/07_auth.yaml
@@ -45,6 +45,14 @@ spec:
       app.kubernetes.io/name: {{ $name }}
   action: ALLOW
   rules:
+  {{- if $environment.auth.allowPaths }}
+  - to:
+    - operation:
+        paths:
+        {{- range $path := $environment.auth.allowPaths }}
+        - {{ $path }}
+        {{- end }}
+  {{- end }}
   - to:
     - operation:
         methods: ['OPTIONS']

--- a/charts/service/values-test-multi.yaml
+++ b/charts/service/values-test-multi.yaml
@@ -30,6 +30,8 @@ environments:
   auth:
     issuer: testing@secure.istio.io
     jwksUri: https://raw.githubusercontent.com/istio/istio/release-1.16/security/tools/jwt/samples/jwks.json
+    allowPaths:
+    - '/metrics'
   public: true
   volumes:
     secrets:


### PR DESCRIPTION
This is necessary as prometheus can't scrape the metrics endpoint otherwise