### PR TITLE
Add overrides section

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,13 @@ jobs:
         run: sudo snap install helm --classic
       - name: Template service chart
         run: cd charts/service && helm template test ./ -f values-test-multi.yaml
+  service-overrides-template:
+    name: Build with multiple environments
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Setup Helm
+        run: sudo snap install helm --classic
+      - name: Template service chart
+        run: cd charts/service && helm template test ./ -f values-test-overrides.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+template.yaml

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: service
-version: 3.7.0
+version: 4.0.0
 description: Helm chart for Circuit service definition

--- a/charts/service/templates/01_rollout.yaml
+++ b/charts/service/templates/01_rollout.yaml
@@ -7,6 +7,9 @@
 {{ $seenMainServiceBefore := 0 }}
 {{- /* */}}
 {{- range $k, $environment := .Values.environments }}
+{{- /* Deploy production environment only when deployProduction override isn't set */}}
+{{ $deployProduction := $.Values.overrides.deployProduction }}
+{{- if or (not $environment.production) $deployProduction }}
 {{ $version := $environment.version | default $.Values.default.version }}
 {{- /* */}}
 {{- if not $environment.name }}
@@ -211,4 +214,5 @@ spec:
       {{- /* */}}
       {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/service/templates/01_rollout.yaml
+++ b/charts/service/templates/01_rollout.yaml
@@ -48,7 +48,7 @@
   {{ $name = $.Values.name }}
 {{- end }}
 {{- if and $.Values.overrides.environmentName }}
-  {{ $name = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
+  {{ $name = printf "%s-%s--%s" $.Values.overrides.environmentName ($environment.name | default "default") $.Values.name }}
 {{- end }}
 {{- /* */}}
 {{ $namespace := $.Values.global.stagingNamespace }}

--- a/charts/service/templates/01_rollout.yaml
+++ b/charts/service/templates/01_rollout.yaml
@@ -11,6 +11,9 @@
 {{ $deployProduction := $.Values.overrides.deployProduction }}
 {{- if or (not $environment.production) $deployProduction }}
 {{ $version := $environment.version | default $.Values.default.version }}
+{{- if and $.Values.overrides.version }}
+  {{ $version = $.Values.overrides.version }}
+{{- end }}
 {{- /* */}}
 {{- if not $environment.name }}
   {{- if not $environment.production }}
@@ -43,6 +46,9 @@
     {{ $seenMainServiceBefore = 1 }}
   {{- end }}
   {{ $name = $.Values.name }}
+{{- end }}
+{{- if and $.Values.overrides.environmentName }}
+  {{ $name = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
 {{- end }}
 {{- /* */}}
 {{ $namespace := $.Values.global.stagingNamespace }}

--- a/charts/service/templates/02_service.yaml
+++ b/charts/service/templates/02_service.yaml
@@ -7,6 +7,9 @@
 {{- if and $environment.production (not $environment.name) }}
   {{ $name = $.Values.name }}
 {{- end }}
+{{- if and $.Values.overrides.environmentName }}
+  {{ $name = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
+{{- end }}
 {{- /* */}}
 {{ $namespace := $.Values.global.stagingNamespace }}
 {{- if $environment.production }}

--- a/charts/service/templates/02_service.yaml
+++ b/charts/service/templates/02_service.yaml
@@ -1,4 +1,7 @@
 {{- range $k, $environment := .Values.environments }}
+{{- /* Deploy production environment only when deployProduction override isn't set */}}
+{{ $deployProduction := $.Values.overrides.deployProduction }}
+{{- if or (not $environment.production) $deployProduction }}
 {{- /* */}}
 {{ $name := printf "%s--%s" $environment.name $.Values.name }}
 {{- if and $environment.production (not $environment.name) }}
@@ -44,4 +47,5 @@ spec:
       name: http
       targetPort: http
 ---
+{{- end }}
 {{- end }}

--- a/charts/service/templates/02_service.yaml
+++ b/charts/service/templates/02_service.yaml
@@ -8,7 +8,7 @@
   {{ $name = $.Values.name }}
 {{- end }}
 {{- if and $.Values.overrides.environmentName }}
-  {{ $name = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
+  {{ $name = printf "%s-%s--%s" $.Values.overrides.environmentName ($environment.name | default "default") $.Values.name }}
 {{- end }}
 {{- /* */}}
 {{ $namespace := $.Values.global.stagingNamespace }}

--- a/charts/service/templates/03_virtualservice.yaml
+++ b/charts/service/templates/03_virtualservice.yaml
@@ -11,6 +11,9 @@
 {{- if and $environment.production (not $environment.name) }}
   {{ $name = $.Values.name }}
 {{- end }}
+{{- if and $.Values.overrides.environmentName }}
+  {{ $name = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
+{{- end }}
 {{- /* */}}
 {{ $namespace := $.Values.global.stagingNamespace }}
 {{- if $environment.production }}

--- a/charts/service/templates/03_virtualservice.yaml
+++ b/charts/service/templates/03_virtualservice.yaml
@@ -12,7 +12,7 @@
   {{ $name = $.Values.name }}
 {{- end }}
 {{- if and $.Values.overrides.environmentName }}
-  {{ $name = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
+  {{ $name = printf "%s-%s--%s" $.Values.overrides.environmentName ($environment.name | default "default") $.Values.name }}
 {{- end }}
 {{- /* */}}
 {{ $namespace := $.Values.global.stagingNamespace }}
@@ -55,11 +55,26 @@ spec:
   {{- if $environment.customRoute }}
 {{ $environment.customRoute | toYaml | indent 2 }}
   {{- end }}
+{{- $overrideHeaders := dict }}
+{{- range $headerName, $headerValue := $.Values.overrides.matchHeaders }}
+  {{- $_ := set $overrideHeaders $headerName (dict "exact" $headerValue) }}
+{{- end }}
   - name: primary
-    {{- if $environment.customMatch }}
+{{- if $environment.customMatch }}
+{{- range $k, $match := $environment.customMatch }}
+  {{- $headers := get $match "headers" | default dict }}
+  {{- $_ := mergeOverwrite $headers $overrideHeaders }}
+  {{- if $headers }}
+    {{- $_ := set $match "headers" $headers }}
+  {{- end }}
+{{- end }}
     match:
 {{ $environment.customMatch | toYaml | indent 4 }}
-    {{- end }}
+{{- else if $overrideHeaders }}
+    match:
+{{- $matchHeaders := list (dict "headers" $overrideHeaders) }}
+{{ $matchHeaders | toYaml | indent 4 }}
+{{- end }}
     route:
     - destination:
         host: {{ printf "%s-stable" $name }}

--- a/charts/service/templates/03_virtualservice.yaml
+++ b/charts/service/templates/03_virtualservice.yaml
@@ -3,6 +3,9 @@
 {{ $gateway := .Values.gateway | default .Values.default.gateway }}
 {{- /* */}}
 {{- range $k, $environment := .Values.environments }}
+{{- /* Deploy production environment only when deployProduction override isn't set */}}
+{{ $deployProduction := $.Values.overrides.deployProduction }}
+{{- if or (not $environment.production) $deployProduction }}
 {{- /* */}}
 {{ $name := printf "%s--%s" $environment.name $.Values.name }}
 {{- if and $environment.production (not $environment.name) }}
@@ -76,4 +79,5 @@ spec:
     {{- end }}
     {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/service/templates/03_virtualservice.yaml
+++ b/charts/service/templates/03_virtualservice.yaml
@@ -67,6 +67,9 @@ spec:
   {{- if $headers }}
     {{- $_ := set $match "headers" $headers }}
   {{- end }}
+  {{- if not $overrideHeaders }}
+    {{- $_ := set $match "withoutHeaders" (dict "circuit-feature-environment" dict ) }}
+  {{- end }}
 {{- end }}
     match:
 {{ $environment.customMatch | toYaml | indent 4 }}

--- a/charts/service/templates/04_hpa.yaml
+++ b/charts/service/templates/04_hpa.yaml
@@ -7,6 +7,9 @@
 {{- if and $environment.production (not $environment.name) }}
   {{ $name = $.Values.name }}
 {{- end }}
+{{- if and $.Values.overrides.environmentName }}
+  {{ $name = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
+{{- end }}
 {{- /* */}}
 {{ $namespace := $.Values.global.stagingNamespace }}
 {{- if $environment.production }}

--- a/charts/service/templates/04_hpa.yaml
+++ b/charts/service/templates/04_hpa.yaml
@@ -8,7 +8,7 @@
   {{ $name = $.Values.name }}
 {{- end }}
 {{- if and $.Values.overrides.environmentName }}
-  {{ $name = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
+  {{ $name = printf "%s-%s--%s" $.Values.overrides.environmentName ($environment.name | default "default") $.Values.name }}
 {{- end }}
 {{- /* */}}
 {{ $namespace := $.Values.global.stagingNamespace }}

--- a/charts/service/templates/04_hpa.yaml
+++ b/charts/service/templates/04_hpa.yaml
@@ -1,4 +1,7 @@
 {{- range $k, $environment := .Values.environments }}
+{{- /* Deploy production environment only when deployProduction override isn't set */}}
+{{ $deployProduction := $.Values.overrides.deployProduction }}
+{{- if or (not $environment.production) $deployProduction }}
 {{- /* */}}
 {{ $name := printf "%s--%s" $environment.name $.Values.name }}
 {{- if and $environment.production (not $environment.name) }}
@@ -27,4 +30,5 @@ spec:
   maxReplicas: {{ $environment.maxReplicas | default $.Values.default.max }}
   targetCPUUtilizationPercentage: {{ $environment.targetCPU | default $.Values.default.target }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/service/templates/05_servicemonitor.yaml
+++ b/charts/service/templates/05_servicemonitor.yaml
@@ -11,7 +11,7 @@
   {{ $name = $.Values.name }}
 {{- end }}
 {{- if and $.Values.overrides.environmentName }}
-  {{ $name = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
+  {{ $name = printf "%s-%s--%s" $.Values.overrides.environmentName ($environment.name | default "default") $.Values.name }}
 {{- end }}
 {{- /* */}}
 {{ $namespace := $.Values.global.stagingNamespace }}

--- a/charts/service/templates/05_servicemonitor.yaml
+++ b/charts/service/templates/05_servicemonitor.yaml
@@ -10,6 +10,9 @@
 {{- if and $environment.production (not $environment.name) }}
   {{ $name = $.Values.name }}
 {{- end }}
+{{- if and $.Values.overrides.environmentName }}
+  {{ $name = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
+{{- end }}
 {{- /* */}}
 {{ $namespace := $.Values.global.stagingNamespace }}
 {{- if $environment.production }}

--- a/charts/service/templates/05_servicemonitor.yaml
+++ b/charts/service/templates/05_servicemonitor.yaml
@@ -1,4 +1,7 @@
 {{- range $k, $environment := .Values.environments }}
+{{- /* Deploy production environment only when deployProduction override isn't set */}}
+{{ $deployProduction := $.Values.overrides.deployProduction }}
+{{- if or (not $environment.production) $deployProduction }}
 {{- /* */}}
 {{- if $environment.metrics }}
 {{- if $environment.metrics.enabled }}
@@ -35,6 +38,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ $name }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/service/templates/06_secrets.yaml
+++ b/charts/service/templates/06_secrets.yaml
@@ -8,7 +8,7 @@
   {{ $secretName = $.Values.name }}
 {{- end }}
 {{- if and $.Values.overrides.environmentName }}
-  {{ $secretName = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
+  {{ $secretName = printf "%s-%s--%s" $.Values.overrides.environmentName ($environment.name | default "default") $.Values.name }}
 {{- end }}
 
 {{ $namespace := $.Values.global.stagingNamespace }}

--- a/charts/service/templates/06_secrets.yaml
+++ b/charts/service/templates/06_secrets.yaml
@@ -1,4 +1,7 @@
 {{- range $k, $environment := .Values.environments }}
+{{- /* Deploy production environment only when deployProduction override isn't set */}}
+{{ $deployProduction := $.Values.overrides.deployProduction }}
+{{- if or (not $environment.production) $deployProduction }}
 
 {{ $secretName := printf "%s--%s" $environment.name $.Values.name }}
 {{- if and $environment.production (not $environment.name) }}
@@ -63,5 +66,6 @@ spec:
   {{- end }}
   {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/service/templates/06_secrets.yaml
+++ b/charts/service/templates/06_secrets.yaml
@@ -7,6 +7,9 @@
 {{- if and $environment.production (not $environment.name) }}
   {{ $secretName = $.Values.name }}
 {{- end }}
+{{- if and $.Values.overrides.environmentName }}
+  {{ $secretName = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
+{{- end }}
 
 {{ $namespace := $.Values.global.stagingNamespace }}
 {{- if $environment.production }}

--- a/charts/service/templates/07_auth.yaml
+++ b/charts/service/templates/07_auth.yaml
@@ -1,4 +1,7 @@
 {{- range $k, $environment := .Values.environments }}
+{{- /* Deploy production environment only when deployProduction override isn't set */}}
+{{ $deployProduction := $.Values.overrides.deployProduction }}
+{{- if or (not $environment.production) $deployProduction }}
 
 {{- if $environment.auth }}
 
@@ -63,4 +66,5 @@ spec:
 ---
 {{- end }}
 
+{{- end }}
 {{- end }}

--- a/charts/service/templates/07_auth.yaml
+++ b/charts/service/templates/07_auth.yaml
@@ -18,7 +18,7 @@
   {{ $name = $.Values.name }}
 {{- end }}
 {{- if and $.Values.overrides.environmentName }}
-  {{ $name = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
+  {{ $name = printf "%s-%s--%s" $.Values.overrides.environmentName ($environment.name | default "default") $.Values.name }}
 {{- end }}
 
 {{ $namespace := $.Values.global.stagingNamespace }}

--- a/charts/service/templates/07_auth.yaml
+++ b/charts/service/templates/07_auth.yaml
@@ -17,6 +17,9 @@
 {{- if and $environment.production (not $environment.name) }}
   {{ $name = $.Values.name }}
 {{- end }}
+{{- if and $.Values.overrides.environmentName }}
+  {{ $name = printf "%s--%s" $.Values.overrides.environmentName $.Values.name }}
+{{- end }}
 
 {{ $namespace := $.Values.global.stagingNamespace }}
 {{- if $environment.production }}

--- a/charts/service/values-test-overrides.yaml
+++ b/charts/service/values-test-overrides.yaml
@@ -26,12 +26,29 @@ environments:
       fromSecret:
         name: staging--secret--value
         version: "1"
+  customMatch:
+  - uri:
+      prefix: "/public/v1"
+  - uri:
+      prefix: "/public/v2"
+    headers:
+      custom-header:
+        exact: jason
+  customDomains:
+  - staging-api.getcircuit.com
   production: false
   name: staging
   imagePullPolicy: Always
   command: ["my", "custom", "command"]
   version: v0.0.2
+- production: false
+  name: test
+  imagePullPolicy: Always
+  command: ["my", "test", "command"]
+  version: v0.0.2
 overrides:
   deployProduction: false
   environmentName: pro-1234-my-branch
   version: pro-1234-my-branch
+  matchHeaders:
+    circuit-feature-environment: pro-1234-my-branch

--- a/charts/service/values-test-overrides.yaml
+++ b/charts/service/values-test-overrides.yaml
@@ -22,6 +22,10 @@ environments:
       prefix: "/health"
 - env:
     TEST_ENV: Staging env var
+    A_SECRET_VALUE: 
+      fromSecret:
+        name: staging--secret--value
+        version: "1"
   production: false
   name: staging
   imagePullPolicy: Always
@@ -29,3 +33,5 @@ environments:
   version: v0.0.2
 overrides:
   deployProduction: false
+  environmentName: pro-1234-my-branch
+  version: pro-1234-my-branch

--- a/charts/service/values-test-overrides.yaml
+++ b/charts/service/values-test-overrides.yaml
@@ -1,0 +1,31 @@
+name: service-template
+environments:
+- env:
+    TEST_ENV: Example env var
+    A_SECRET_VALUE: 
+      fromSecret:
+        name: staging--secret--value
+        version: "1"
+    ANOTHER_SECRET_VALUE: 
+      fromSecret:
+        name: very--secret
+        version: latest
+  production: true
+  version: v0.0.2
+  customDomains:
+  - api.getcircuit.com
+  - api-test.getcircuit.com
+  customMatch:
+  - uri:
+      prefix: "/rest"
+  - uri:
+      prefix: "/health"
+- env:
+    TEST_ENV: Staging env var
+  production: false
+  name: staging
+  imagePullPolicy: Always
+  command: ["my", "custom", "command"]
+  version: v0.0.2
+overrides:
+  deployProduction: false

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -49,3 +49,5 @@ mirror:
 global:
   prodNamespace: apps
   stagingNamespace: staging--apps
+overrides:
+  deployProduction: true

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -53,3 +53,4 @@ overrides:
   deployProduction: true
   environmentName:
   version:
+  matchHeaders:

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -51,3 +51,5 @@ global:
   stagingNamespace: staging--apps
 overrides:
   deployProduction: true
+  environmentName:
+  version:


### PR DESCRIPTION
- Add overrides section to be used by feature-environments
- Add `withoutHeaders` ([read more here](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest)) section on environments with customRoute and no header override. This prevents requests with feature-environment header from hitting another environment.