### PR TITLE
Fix being able to bypass authzpolicy from another ns

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: service
-version: 4.2.0
+version: 4.2.1
 description: Helm chart for Circuit service definition

--- a/charts/service/templates/09_cluster_auth.yaml
+++ b/charts/service/templates/09_cluster_auth.yaml
@@ -46,8 +46,6 @@ spec:
           {{- end }}
       from:
       - source:
-          namespaces:
-            - {{ $namespace }}
           notPrincipals:
             {{- if not (kindIs "slice" $route.services) }}
               {{ fail "clusterAuth.routes.services must be a list" }}


### PR DESCRIPTION
This would happen as the `namespaces` is ANDed together with the `notPrincipals`, thus if `notPrincipals` is `true`(principal does not match) and `namespaces` is `false`, it would evaluate the policy to `false`, thus it would not deny it. As a SA can only be used from one namespace, the `notPrincipals` check is sufficient.
