### PR TITLE
Add support for multiple token issuers

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: service
-version: 4.2.1
+version: 5.0.0
 description: Helm chart for Circuit service definition

--- a/charts/service/templates/07_auth.yaml
+++ b/charts/service/templates/07_auth.yaml
@@ -5,12 +5,8 @@
 
 {{- if $environment.auth }}
 
-{{- if not $environment.auth.issuer }}
-{{ fail "You must provide the issuer when enabling auth" }}
-{{- end }}
-
-{{- if not $environment.auth.jwksUri }}
-{{ fail "You must provide the jwksUri when enabling auth" }}
+{{- if not $environment.auth.issuers }}
+{{ fail "You must provide the issuers when enabling auth" }}
 {{- end }}
 
 {{ $name := printf "%s--%s" $environment.name $.Values.name }}
@@ -36,9 +32,18 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ $name }}
   jwtRules:
-  - issuer: {{ $environment.auth.issuer }}
-    jwksUri: {{ $environment.auth.jwksUri }}
+  {{- range $issuer := $environment.auth.issuers }}
+  {{- if not $issuer.iss }}
+  {{ fail "You must provide the iss for each issuer" }}
+  {{- end }}
+
+  {{- if not $issuer.jwksUri }}
+  {{ fail "You must provide the jwksUri for each issuer" }}
+  {{- end }}
+  - issuer: {{ $issuer.iss }}
+    jwksUri: {{ $issuer.jwksUri }}
     forwardOriginalToken: true
+  {{- end }}
 ---
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy

--- a/charts/service/values-test-multi.yaml
+++ b/charts/service/values-test-multi.yaml
@@ -28,8 +28,9 @@ environments:
   version: v0.0.2
   targetCPU: 80
   auth:
-    issuer: testing@secure.istio.io
-    jwksUri: https://raw.githubusercontent.com/istio/istio/release-1.16/security/tools/jwt/samples/jwks.json
+    issuers:
+      - iss: testing@secure.istio.io
+        jwksUri: https://raw.githubusercontent.com/istio/istio/release-1.16/security/tools/jwt/samples/jwks.json
     allowPaths:
     - '/metrics'
   public: true
@@ -105,8 +106,9 @@ environments:
   port: 3000
   production: false
   auth:
-    issuer: testing@secure.istio.io
-    jwksUri: https://raw.githubusercontent.com/istio/istio/release-1.16/security/tools/jwt/samples/jwks.json
+    issuers:
+      - iss: testing@secure.istio.io
+        jwksUri: https://raw.githubusercontent.com/istio/istio/release-1.16/security/tools/jwt/samples/jwks.json
   name: staging
   gcpServiceAccount: "suchGcpServiceAccount@veryemail.com"
   imagePullPolicy: Always


### PR DESCRIPTION
Context: https://twist.com/a/65306/ch/410323/t/4129579/c/83563235

As we move projects from `circuit-for-teams` to `circuit-prod` we'll have users that can have tokens from either project. Our services should accept tokens from both, and therefore we need to add support for multiple token issuers.