### PR TITLE
Fix envoy drain period not matching the main container one

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: service
-version: 5.2.0
+version: 5.2.1
 description: Helm chart for Circuit service definition

--- a/charts/service/templates/01_rollout.yaml
+++ b/charts/service/templates/01_rollout.yaml
@@ -126,6 +126,12 @@ spec:
         istio-injection: enabled
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        {{- if $environment.terminationGracePeriodSeconds }}
+        proxy.istio.io/config: {{ printf 
+          "{\"proxyMetadata\":{\"EXIT_ON_ZERO_ACTIVE_CONNECTIONS\":\"true\"}, \"terminationDrainDuration\":\"%ds\"}"
+          (int $environment.terminationGracePeriodSeconds) 
+          | quote }}
+        {{- end }}
     spec:
       {{- if $environment.gcpServiceAccount }}
       serviceAccountName: {{ $name }}


### PR DESCRIPTION
This should ensure that our pods have enough time to perform a graceful shutdown without being cut out from making connections.