### PR TITLE
Reorder HPA metrics to match K8s ordering

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: service
-version: 5.3.0
+version: 5.3.1
 description: Helm chart for Circuit service definition

--- a/charts/service/templates/04_hpa.yaml
+++ b/charts/service/templates/04_hpa.yaml
@@ -32,20 +32,6 @@ spec:
   minReplicas: {{ $environment.minReplicas | default $.Values.default.min }}
   maxReplicas: {{ $environment.maxReplicas | default $.Values.default.max }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ $environment.targetCPU | default $.Values.default.target }}
-  {{- if and $environment.targetMemory }}
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: {{ $environment.targetMemory }}
-  {{- end }}
   {{- range $l, $targetCustomMetrics := $environment.targetCustomMetrics }}
   - type: Pods
     pods:
@@ -55,6 +41,20 @@ spec:
         type: AverageValue
         averageValue: {{ $targetCustomMetrics.value }}
   {{- end }}
+  {{- if and $environment.targetMemory }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ $environment.targetMemory }}
+  {{- end }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ $environment.targetCPU | default $.Values.default.target }}
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This is a fix for K8s always re-ordering HPA metrics and keeping ArgoCD out of sync.

See this issue: https://github.com/kubernetes/kubernetes/issues/74099