### PR TITLE
Add 'enabled' flag for envs with secrets

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: service
-version: 5.4.0
+version: 5.5.0
 description: Helm chart for Circuit service definition

--- a/charts/service/templates/01_rollout.yaml
+++ b/charts/service/templates/01_rollout.yaml
@@ -192,7 +192,7 @@ spec:
           {{- /* */}}
           env:
           {{- range $key, $value := $environment.env}}
-            {{- if and (kindIs "map" $value) }}
+            {{- if kindIs "map" $value }}
             {{- $secret := $value.fromSecret }}
             {{- if or (not (hasKey $secret "enabled")) ($secret.enabled) }}
           - name: {{ $key | quote }}

--- a/charts/service/templates/01_rollout.yaml
+++ b/charts/service/templates/01_rollout.yaml
@@ -192,13 +192,15 @@ spec:
           {{- /* */}}
           env:
           {{- range $key, $value := $environment.env}}
-            {{- if kindIs "map" $value }}
+            {{- if and (kindIs "map" $value) }}
             {{- $secret := $value.fromSecret }}
+            {{- if or (not (hasKey $secret "enabled")) ($secret.enabled) }}
           - name: {{ $key | quote }}
             valueFrom: 
               secretKeyRef:
                 name: {{ $name | quote }}
                 key: {{ include "secrets.key.env" (dict "key" $key "secret" $secret) }}
+            {{- end }}
             {{- else}}
           - name: {{ $key | quote }}
             value: {{ $value | quote }}

--- a/charts/service/values-test-multi.yaml
+++ b/charts/service/values-test-multi.yaml
@@ -10,6 +10,11 @@ environments:
       fromSecret:
         name: very--secret
         version: latest
+    A_DISABLED_SECRET_VALUE: 
+      fromSecret:
+        name: disabled--secret
+        version: "1"
+        enabled: false
   metrics:
     enabled: true
     interval: 10s

--- a/charts/service/values-test-multi.yaml
+++ b/charts/service/values-test-multi.yaml
@@ -15,6 +15,11 @@ environments:
         name: disabled--secret
         version: "1"
         enabled: false
+    AN_ENABLED_SECRET_VALUE: 
+      fromSecret:
+        name: enabled--secret
+        version: "1"
+        enabled: true
   metrics:
     enabled: true
     interval: 10s


### PR DESCRIPTION
This will help with a phased rollout when removing a secret.

First we set the secret as `enabled: false`, which means that the ESO secret still exists but it will not be mounted in the Pod as an env var anymore.

Then, after the rollout is complete and we validate that it is working we remove it, so that the secret does not exist anymore.

This will allow older versions of the rollout coexist with newer ones as the secret will still be able to be mounted for the older versions in case it scales up or if the rollout rolls back.